### PR TITLE
Add 0.0.3-3.rockspec

### DIFF
--- a/rockspecs/vert-0.0.3-3.rockspec
+++ b/rockspecs/vert-0.0.3-3.rockspec
@@ -1,0 +1,37 @@
+package = "Vert"
+
+version = "0.0.3-3"
+
+source = { url = "git://github.com/aconbere/vert.git"
+         }
+
+description = { summary = "Creates isolated development environment"
+              , detailed = [[
+                  Vert is a tool for building isolated development environments akin to
+                  virtualenv in python. It handles compiling and install lua to a local
+                  directory as well as setting up luarocks.
+                ]]
+              , license = "MIT/X11"
+              , maintainer = "Anders Conbere <aconbere@gmail.com>"
+              }
+
+dependencies = { "lua >= 5.1"
+               , "luafilesystem"
+               , "luasocket"
+               }
+
+build = { type = "builtin"
+        , modules = { optimal         = "./src/optimal.lua"
+                    , utils           = "./src/utils.lua"
+                    , vert_initialize = "./src/vert_initialize.lua"
+                    , vert_list       = "./src/vert_list.lua"
+                    , vert_make       = "./src/vert_make.lua"
+                    , vert_remove     = "./src/vert_remove.lua"
+                    , vert            = "./src/vert.lua"
+                    }
+
+        , install = { bin = { vert         = "src/vert.lua"
+                            , vert_wrapper = "src/vert_wrapper.sh"
+                            }
+                    }
+        }


### PR DESCRIPTION
Hi, I like this library.

But, when I ran at MacOSX following error messages raised.
```
EXECUTING:	make linux
cd src && /Applications/Xcode.app/Contents/Developer/usr/bin/make linux
/Applications/Xcode.app/Contents/Developer/usr/bin/make all SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
gcc -o lua   lua.o liblua.a -lm -Wl,-E -ldl -lreadline 
ld: unknown option: -E
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lua] Error 1
make[1]: *** [linux] Error 2
make: *** [linux] Error 2
make lua failed
```

This is because current 0.0.3-2.rockspec is specified `0.0.3`.
And `0.0.3` ignore PLATFORM option.

So, I've update new `0.0.3-3.rockspec`.
Please check, merge and release to LuaRocks repo.